### PR TITLE
fix(process.sh): syntax for uname interpolation now correct

### DIFF
--- a/tools/process.sh
+++ b/tools/process.sh
@@ -11,40 +11,40 @@ rm -rf work_old
 rm -rf hs.*
 mkdir work
 cat $2 > work/hs.app
-./tools/ctrtool-($uname) -x --contents work/ciacnt $1 &>/dev/null
+./tools/ctrtool-$(uname) -x --contents work/ciacnt $1 &>/dev/null
 mv work/ciacnt.0000.* work/inject.app
 
 printf "[+] EXTRACT HS AND INJECT APP\n"
-./tools/3dstool-($uname) -x -f work/hs.app --header work/hs_hdr.bin --exh work/hs_exhdr.bin --plain work/hs_plain.bin --logo work/hs_logo.bin --exefs work/hs_exefs.bin --romfs work/hs_romfs.bin &>/dev/null
-./tools/3dstool-($uname) -x -f work/inject.app --exh work/inject_exhdr.bin --exefs work/inject_exefs.bin &>/dev/null
-./tools/3dstool-($uname) -x -f work/hs_exefs.bin --exefs-dir work/hs_exefs &>/dev/null
-./tools/3dstool-($uname) -x -f work/inject_exefs.bin --exefs-dir work/inject_exefs &>/dev/null
+./tools/3dstool-$(uname) -x -f work/hs.app --header work/hs_hdr.bin --exh work/hs_exhdr.bin --plain work/hs_plain.bin --logo work/hs_logo.bin --exefs work/hs_exefs.bin --romfs work/hs_romfs.bin &>/dev/null
+./tools/3dstool-$(uname) -x -f work/inject.app --exh work/inject_exhdr.bin --exefs work/inject_exefs.bin &>/dev/null
+./tools/3dstool-$(uname) -x -f work/hs_exefs.bin --exefs-dir work/hs_exefs &>/dev/null
+./tools/3dstool-$(uname) -x -f work/inject_exefs.bin --exefs-dir work/inject_exefs &>/dev/null
 
 printf "[+] GENERATE NEW EXEFS\n"
 cp work/inject_exefs/code.bin work/hs_exefs/code.bin
-./tools/3dstool-($uname) -c -z -t exefs -f work/hs_mod_exefs.bin --exefs-dir work/hs_exefs --header work/hs_exefs.bin &>/dev/null
+./tools/3dstool-$(uname) -c -z -t exefs -f work/hs_mod_exefs.bin --exefs-dir work/hs_exefs --header work/hs_exefs.bin &>/dev/null
 cp work/inject_exefs/banner.bnr work/hs_exefs/banner.bnr
 cp work/inject_exefs/icon.icn work/hs_exefs/icon.icn
-./tools/3dstool-($uname) -c -z -t exefs -f work/hs_mod_banner_exefs.bin --exefs-dir work/hs_exefs --header work/hs_exefs.bin &>/dev/null
+./tools/3dstool-$(uname) -c -z -t exefs -f work/hs_mod_banner_exefs.bin --exefs-dir work/hs_exefs --header work/hs_exefs.bin &>/dev/null
 
 printf "[+] GENERATE NEW ROMFS\n"
 mkdir work/dummy_romfs
 cp tools/dummy.bin work/dummy_romfs/dummy.bin
-./tools/3dstool-($uname) -c -t romfs -f work/dummy_romfs.bin --romfs-dir work/dummy_romfs &>/dev/null
+./tools/3dstool-$(uname) -c -t romfs -f work/dummy_romfs.bin --romfs-dir work/dummy_romfs &>/dev/null
 
 printf "[+] MERGE EXHEADER\n"
-./tools/MergeExHeader-($uname) work/inject_exhdr.bin work/hs_exhdr.bin work/merge_exhdr.bin &>/dev/null
+./tools/MergeExHeader-$(uname) work/inject_exhdr.bin work/hs_exhdr.bin work/merge_exhdr.bin &>/dev/null
 
 printf "[+] REBUILD HS INJECT APP\n"
 
 if [ -e work/hs_logo.bin ]
-then ./tools/3dstool-($uname) -c -t cxi -f ${1%.*}_inject_no_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --logo work/hs_logo.bin --exefs work/hs_mod_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
-else ./tools/3dstool-($uname) -c -t cxi -f ${1%.*}_inject_no_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --exefs work/hs_mod_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
+then ./tools/3dstool-$(uname) -c -t cxi -f ${1%.*}_inject_no_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --logo work/hs_logo.bin --exefs work/hs_mod_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
+else ./tools/3dstool-$(uname) -c -t cxi -f ${1%.*}_inject_no_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --exefs work/hs_mod_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
 fi
 
 if [ -e work/hs_logo.bin ]
-then ./tools/3dstool-($uname) -c -t cxi -f ${1%.*}_inject_with_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --logo work/hs_logo.bin --exefs work/hs_mod_banner_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
-else ./tools/3dstool-($uname) -c -t cxi -f ${1%.*}_inject_with_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --exefs work/hs_mod_banner_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
+then ./tools/3dstool-$(uname) -c -t cxi -f ${1%.*}_inject_with_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --logo work/hs_logo.bin --exefs work/hs_mod_banner_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
+else ./tools/3dstool-$(uname) -c -t cxi -f ${1%.*}_inject_with_banner.app --header work/hs_hdr.bin --exh work/merge_exhdr.bin --plain work/hs_plain.bin --exefs work/hs_mod_banner_exefs.bin --romfs work/dummy_romfs.bin &>/dev/null
 fi
 
 for i in work/hs.app; do HS_ORIGINAL_SIZE=$(ls -l $i | awk '{print $5}'); done


### PR DESCRIPTION
Had this error.

```
~/3ds/git/Universal-Inject-Generator sh-typos ❯ ./go.sh
 --- UNIVERSAL INJECT GENERATOR V0.3 ---
          --- LINUX EDITION ---


[+] IDENTIFY FILES TO WORK WITH
mv: rename work to work_old: No such file or directory
tools/process.sh: line 14: syntax error near unexpected token `$uname'
tools/process.sh: line 14: `./tools/ctrtool-($uname) -x --contents work/ciacnt $1 &>/dev/null'
```

`uname` command typo.
Fixed the problem.

```
 --- UNIVERSAL INJECT GENERATOR V0.3 ---
          --- LINUX EDITION ---


[+] IDENTIFY FILES TO WORK WITH
[+] EXTRACT HS AND INJECT APP
[+] GENERATE NEW EXEFS
[+] GENERATE NEW ROMFS
[+] MERGE EXHEADER
[+] REBUILD HS INJECT APP
[+] HS APP ORIGINAL SIZE  : 1040384 bytes
[+] HS APP INJECT (N) SIZE: 704512 bytes
[+] HS APP INJECT (B) SIZE: 827392 bytes
```
